### PR TITLE
Update README.md: added sudo usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can check out his [Apache version here](https://github.com/jbfink/docker-wor
 ```
 $ git clone https://github.com/eugeneware/docker-wordpress-nginx.git
 $ cd docker-wordpress-nginx
-$ docker build -t="docker-wordpress-nginx" .
+$ sudo docker build -t="docker-wordpress-nginx" .
 ```
 
 ## Usage
@@ -19,7 +19,7 @@ $ docker build -t="docker-wordpress-nginx" .
 To spawn a new instance of wordpress:
 
 ```bash
-$ docker run -d docker-wordpress-nginx
+$ sudo docker run -d docker-wordpress-nginx
 ```
 
 You'll see an ID output like:
@@ -29,5 +29,5 @@ d404cc2fa27b
 
 Use this ID to check the port it's on:
 ```bash
-$ docker port d404cc2fa27b 80 # Make sure to change the ID to yours!
+$ sudo docker port d404cc2fa27b 80 # Make sure to change the ID to yours!
 ```


### PR DESCRIPTION
Since [docker 0.5.2](http://blog.docker.io/2013/08/containers-docker-how-secure-are-they/#specific-attack-surface-of-the-docker-daemon) `sudo` is required:

> For this reason, the REST API endpoint (used by the Docker CLI to communicate with the Docker daemon) changed in Docker 0.5.2, and now uses a UNIX socket instead of a TCP socket bound on 127.0.0.1 (the latter being prone to cross-site-scripting attacks if you happen to run Docker directly on your local machine, outside of a VM). You can then use traditional UNIX permission checks to limit access to the control socket.
