### PR TITLE
Dockerfile: added 'client_max_body_size 3m' into nginx.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysq
 
 # nginx config
 RUN sed -i -e"s/keepalive_timeout\s*65/keepalive_timeout 2/" /etc/nginx/nginx.conf
+# since 'upload_max_filesize = 2M' in /etc/php5/fpm/php.ini
+RUN sed -i -e"s/keepalive_timeout 2/keepalive_timeout 2;\n\tclient_max_body_size 3m/" /etc/nginx/nginx.conf
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 
 # php-fpm config


### PR DESCRIPTION
To be able to upload themes larger than 1M
(default value of the `client_max_body_size` is 1m in `nginx.conf`)
