### PR TITLE
Nginx/virtualbox bug - disable sendfile

### DIFF
--- a/nginx-site.conf
+++ b/nginx-site.conf
@@ -27,7 +27,8 @@ server {
 	# Make site accessible from http://localhost/
 	server_name localhost;
 	
-	sendfile off; # as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+	# Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+	sendfile off;
 
 	location / {
 		# First attempt to serve request as file, then


### PR DESCRIPTION
Hi,

Thanks for this Dockerfile, it was really handy!

I don't know whether your project is worried about this because not everyone's using VirtualBox, but if you are, this PR implements a fix as described at https://docs.vagrantup.com/v2/synced-folders/virtualbox.html to this problem with shared filesystems: http://smotko.si/nginx-static-file-problem/

If you're just using Wordpress inside the docker image you may not notice this issue.

I came across this as I'd mounted a synced folder to do some plugin development and some files weren't being refreshed as per screenshot on the smotko.si post. This seems to impact static files only, as Nginx passes other requests to PHP which doesn't have the same issue.

Cheers,
Josh
